### PR TITLE
Stop statement about resetting measure when resampling=nothing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJIteration"
 uuid = "614be32b-d00c-4edb-bd02-1eb411ab5e55"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 IterationControl = "b3c1a2ee-3fec-4384-bf48-272ea71de57c"

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -215,7 +215,8 @@ end
 
 function MLJBase.clean!(iterated_model::EitherIteratedModel)
     message = ""
-    if iterated_model.measure === nothing
+    if iterated_model.measure === nothing &&
+        iterated_model.resampling !== nothing
         iterated_model.measure = MLJBase.default_measure(iterated_model.model)
         if iterated_model.measure === nothing
             throw(ERR_NEED_MEASURE)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -20,6 +20,8 @@ struct Bar <: MLJBase.Deterministic end
                IteratedModel(model=model))
     @test iterated_model.measure == RootMeanSquaredError()
     @test_logs IteratedModel(model=model, measure=mae)
+
+    iterated_model = @test_logs IteratedModel(model=model, resampling=nothing)
 end
 
 end


### PR DESCRIPTION
When `resampling=nothing` the specified `measure` plays no role. Currently, the constructor is issuing an `@info` saying that the measure is being set when not specified. 

