### PR TITLE
Remove warnings when `resampling=Holdout(rng=...)` 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJIteration"
 uuid = "614be32b-d00c-4edb-bd02-1eb411ab5e55"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 IterationControl = "b3c1a2ee-3fec-4384-bf48-272ea71de57c"

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -23,10 +23,18 @@ struct Bar <: MLJBase.Deterministic end
 
     @test_logs IteratedModel(model=model, resampling=nothing)
 
-    @test_logs((:info, r"The use of sample"),
+    @test_logs((:info, r"`resampling` must be"),
                IteratedModel(model=model,
-                             resampling=Holdout(rng=123),
+                             resampling=CV(),
                              measure=rms))
+    @test_logs((:info, r"A `resampling` vector may contain"),
+               IteratedModel(model=model,
+                             resampling=[([1, 2], [3, 4]),
+                                         ([3, 4], [1, 2])],
+                             measure=rms))
+    @test_logs IteratedModel(model=model,
+                             resampling=[([1, 2], [3, 4]),],
+                             measure=rms)
 
     @test_throws(MLJIteration.ERR_MISSING_TRAINING_CONTROL,
                  IteratedModel(model=model,


### PR DESCRIPTION
In light of https://github.com/alan-turing-institute/MLJBase.jl/pull/559, this PR removes warnings added to mitigate #12, which did not really resolve the issue, but which the recent MLJBase PR renders moot. 

Specifically, `resampling` can now be `nothing`, any `Holdout`, or any vector of the form `[(train, test), ]`, where `train` and `test` are vectors of valid row indices for the data, and there will be no "cold restart" issues. 