### PR TITLE
Fix tests for change in `|>` in MLJBase 0.19 (backwards compatible fix)

### DIFF
--- a/test/controls.jl
+++ b/test/controls.jl
@@ -143,7 +143,7 @@ const N = 20
                 local model = DummyIterativeModel(n=n)
                 local mach = machine(model, X, y)
                 fit!(mach, verbosity=0)
-                t = mach |> EXT_GIVEN_STR[$str] |> PROJECTION_GIVEN_STR[$str]
+                t = PROJECTION_GIVEN_STR[$str](mach |> EXT_GIVEN_STR[$str])
                 push!(trace_by_hand, t)
             end
 


### PR DESCRIPTION
In tests had `model |> f` which now means `Pipeline(model, f)`. This PR replaces it with `f(model)` the intended meaning. 

Testing only change. No new release.