### PR TITLE
Fix `iteration_parameter` precedence.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [compat]
 IterationControl = "0.5"
 MLJBase = "0.18.8, 0.19"
-julia = "1"
+julia = "1.6"
 
 [extras]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"

--- a/src/core.jl
+++ b/src/core.jl
@@ -51,11 +51,7 @@ end
 function MLJBase.fit(iterated_model::EitherIteratedModel, verbosity, data...)
 
     model = deepcopy(iterated_model.model)
-
-     # get name of iteration parameter:
-     _iter = MLJBase.iteration_parameter(model)
-    iteration_param = _iter === nothing ?
-        iterated_model.iteration_parameter : _iter
+    iteration_param = iterated_model.iteration_parameter
 
     # instantiate `train_mach`:
     mach = if iterated_model.resampling === nothing

--- a/src/ic_model.jl
+++ b/src/ic_model.jl
@@ -52,7 +52,7 @@ end
 # overloading `expose`- for `resampling === nothing`:
 IterationControl.expose(ic_model::ICModel) = ic_model.mach
 
-# overloading `expose`- for `resampling isa Holdout` or 
+# overloading `expose`- for `resampling isa Holdout` or
 # other resampling strategy:
 IterationControl.expose(ic_model::ICModel{<:Machine{<:Resampler}}) =
     MLJBase.fitted_params(ic_model.mach).machine

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -11,7 +11,8 @@ struct FooBar <: MLJBase.Deterministic end
 
 @testset "constructors" begin
     model = DummyIterativeModel()
-    @test_throws MLJIteration.ERR_NO_MODEL IteratedModel()
+    @test_throws MLJIteration.ERR_TOO_MANY_ARGUMENTS IteratedModel(1, 2)
+    @test_throws MLJIteration.ERR_MODEL_UNSPECIFIED IteratedModel()
     @test_throws MLJIteration.ERR_NOT_SUPERVISED IteratedModel(model=Foo())
     @test_throws MLJIteration.ERR_NOT_SUPERVISED IteratedModel(model=Int)
     @test_throws MLJIteration.ERR_NEED_MEASURE IteratedModel(model=Bar())
@@ -25,6 +26,7 @@ struct FooBar <: MLJBase.Deterministic end
     @test iterated_model.measure == RootMeanSquaredError()
     @test iterated_model.iteration_parameter == :n
     @test_logs IteratedModel(model=model, measure=mae, iteration_parameter=:n)
+    @test_logs IteratedModel(model, measure=mae, iteration_parameter=:n)
 
     @test_logs IteratedModel(model=model, resampling=nothing, iteration_parameter=:n)
 


### PR DESCRIPTION
Addresses #40, and also #41.

Bumps julia compat to 1.6 (dependency MLJBase is already there)