### PR TITLE
fix method duplication

### DIFF
--- a/src/traits.jl
+++ b/src/traits.jl
@@ -12,21 +12,23 @@ MLJBase.package_url(::Type{<:EitherIteratedModel}) =
 MLJBase.package_license(::Type{<:EitherIteratedModel}) = "MIT"
 
 # inherited traits:
-for T in [:DeterministicIteratedModel, :ProbabilisticIteratedModel]
-    for trait in [:supports_weights,
-                  :supports_class_weights,
-                  :is_pure_julia,
-                  :input_scitype,
-                  :output_scitype,
-                  :target_scitype]
+for trait in [:supports_weights,
+              :supports_class_weights,
+              :is_pure_julia,
+              :input_scitype,
+              :output_scitype,
+              :target_scitype]
+    quote
+        # needed because traits are not always deducable from
+        # the type (eg, `target_scitype` and `Pipeline` models):
+        MLJBase.$trait(imodel::EitherIteratedModel) = $trait(imodel.model)
+    end |> eval
+    for T in [:DeterministicIteratedModel, :ProbabilisticIteratedModel]
         quote
             # try to get trait at level of types ("failure" here just
             # means falling back to `Unknown`):
             MLJBase.$trait(::Type{<:$T{M}}) where M = MLJBase.$trait(M)
-
-            # needed because traits are not always deducable from
-            # the type (eg, `target_scitype` and `Pipeline` models):
-            MLJBase.$trait(imodel::EitherIteratedModel) = $trait(imodel.model)
         end |> eval
     end
 end
+

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -31,4 +31,3 @@ for trait in [:supports_weights,
         end |> eval
     end
 end
-


### PR DESCRIPTION
Currently, the `MLJBase.$trait(::EitherIteratedModel)` methods are getting inadvertently duplicated in `traits.jl`, resulting in warnings like the following
```
WARNING: Method definition supports_class_weights(Union{MLJIteration.DeterministicIteratedModel{M}, MLJIteration.ProbabilisticIteratedModel{M}} where M) in module MLJIteration at /home/expandingman/.julia/packages/MLJIteration/OZRTw/src/traits.jl:29 overwritten on the same line (check for duplicate calls to `include`).
  ** incremental compilation may be fatally broken for this module **
```

This PR removes the duplication be re-arranging the evaluation loops.