### PR TITLE
Add feature importances support to iterated models

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -155,3 +155,11 @@ MLJBase.transform(::EitherIteratedModel, fitresult, Xnew) =
 # here `fitresult` is a trained atomic machine:
 MLJBase.save(::EitherIteratedModel, fitresult) = MLJBase.serializable(fitresult)
 MLJBase.restore(::EitherIteratedModel, fitresult) = MLJBase.restore!(fitresult)
+
+# Feature importances
+function MLJBase.feature_importances(::EitherIteratedModel, fitresult, report)
+    # fitresult here is the curent state of the iterated machine 
+    # The line below will return `nothing` when the iteration model doesn't
+    # support feature_importances.
+    return MLJBase.feature_importances(fitresult)
+end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -15,6 +15,7 @@ for trait in [:supports_weights,
               :is_pure_julia,
               :input_scitype,
               :output_scitype,
+              :reports_feature_importances,
               :target_scitype]
     quote
         # needed because traits are not always deducable from

--- a/test/traits.jl
+++ b/test/traits.jl
@@ -23,6 +23,7 @@ imodel = IteratedModel(model=model, measure=mae)
 @test output_scitype(imodel) == output_scitype(model)
 @test target_scitype(imodel) == target_scitype(model)
 @test constructor(imodel) == IteratedModel
+@test reports_feature_importances(imodel) == reports_feature_importances(model)
 
 end
 


### PR DESCRIPTION
closes #66 

```julia

julia> using MLJIteration, MLJBase, StatisticalMeasures

julia> X, y = make_moons(100, rng=123);

julia> iterated_model = IteratedModel(
           model=XGBoostClassifier(seed=123),
           resampling=Holdout(rng=123),
           measures=log_loss,
           iteration_parameter = :num_round,
           controls=[Step(2), Patience(2), NumberLimit(5)],
           retrain=true
       );

julia> mach = machine(iterated_model, X, y) |> fit!;
[ Info: Training machine(ProbabilisticIteratedModel(model = XGBoostClassifier(test = 1, …), …), …).
[ Info: final loss: 0.24434335559754639
[ Info: Stop triggered by NumberLimit(5) stopping criterion.
[ Info: Retraining on all provided data. To suppress, specify `retrain=false`.
[ Info: Total of 10 iterations.

julia> mach |> feature_importances
2-element Vector{Pair{Symbol, Float32}}:
 :x2 => 9.344354
 :x1 => 1.4283949
```